### PR TITLE
[WIP] Sles12sp3 trial

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -830,7 +830,7 @@ sub load_inst_tests {
                 && is_server()
                 && (!is_sles4sap() || is_sles4sap_standard())
                 && (install_this_version() || install_to_other_at_least('12-SP2'))
-                || sle_version_at_least('15')))
+                || is_sle('15+')))
         {
             loadtest "installation/system_role";
         }

--- a/products/opensuse/templates
+++ b/products/opensuse/templates
@@ -3594,6 +3594,19 @@
                       },
                       test_suite => { name => "minimalx" },
                     },
+                    {
+                      group_name => "SLES 12 SP3 PowerPC",
+                      machine => { name => "ppc64le" },
+                      prio => 50,
+                      product => {
+                        arch    => "ppc64le",
+                        distri  => "sle",
+                        flavor  => "Server-DVD",
+                        group   => "sle-12-SP3-Server-DVD",
+                        version => "*",
+                      },
+                      test_suite => { name => "install_gnome" }
+                    },
                   ],
   Machines     => [
                     {
@@ -4024,6 +4037,17 @@
                                   ],
                       version  => "15.0",
                     },
+                    {
+                      arch     => "ppc64le",
+                      distri   => "sle",
+                      flavor   => "Server-DVD",
+                      settings => [
+                                    { key => "DVD", value => 1 },
+                                    { key => "ISO_MAXSIZE", value => 4700372992 },
+                                    { key => "NOIMAGES", value => 1 },
+                                  ],
+                      version  => "*",
+                    },
                   ],
   TestSuites   => [
                     {
@@ -4215,6 +4239,13 @@
                       name => "install_minimalx",
                       settings => [
                         { key => "DESKTOP", value => "minimalx" },
+                        { key => "INSTALLONLY", value => 1 },
+                      ],
+                    },
+                    {
+                      name => "install_gnome",
+                      settings => [
+                        { key => "DESKTOP", value => "gnome" },
                         { key => "INSTALLONLY", value => 1 },
                       ],
                     },

--- a/products/opensuse/templates
+++ b/products/opensuse/templates
@@ -3607,6 +3607,19 @@
                       },
                       test_suite => { name => "install_gnome" }
                     },
+                    {
+                      group_name => "SLES 15 PowerPC",
+                      machine => { name => "ppc64le" },
+                      prio => 50,
+                      product => {
+                        arch    => "ppc64le",
+                        distri  => "sle",
+                        flavor  => "Server-DVD",
+                        group   => "sle-15-Server-DVD",
+                        version => "15.0",
+                      },
+                      test_suite => { name => "install_textmode" }
+                    },
                   ],
   Machines     => [
                     {
@@ -4050,6 +4063,20 @@
                                   ],
                       version  => "*",
                     },
+                    {
+                      description => "force SCC_REGISTER to avoid registration, BETA is set.",
+                      arch     => "ppc64le",
+                      distri   => "sle",
+                      flavor   => "Server-DVD",
+                      settings => [
+                                    { key => "DVD", value => 1 },
+                                    { key => "ISO_MAXSIZE", value => 4700372992 },
+                                    { key => "NOIMAGES", value => 1 },
+                                    { key => "SCC_REGISTER", value => "never" },
+                                    { key => "BETA", value => 1 },
+                                  ],
+                      version  => "15.0",
+                    },
                   ],
   TestSuites   => [
                     {
@@ -4248,6 +4275,14 @@
                       name => "install_gnome",
                       settings => [
                         { key => "DESKTOP", value => "gnome" },
+                        { key => "INSTALLONLY", value => 1 },
+                      ],
+                    },
+                    {
+                      description => "set target DESKTOP as textmode but do not set VIDEOMODE as such to keep installation as GUI.",
+                      name => "install_textmode",
+                      settings => [
+                        { key => "DESKTOP", value => "textmode" },
                         { key => "INSTALLONLY", value => 1 },
                       ],
                     },

--- a/products/opensuse/templates
+++ b/products/opensuse/templates
@@ -4038,6 +4038,7 @@
                       version  => "15.0",
                     },
                     {
+                      description => "force SCC_REGISTER to avoid registration.",
                       arch     => "ppc64le",
                       distri   => "sle",
                       flavor   => "Server-DVD",
@@ -4045,6 +4046,7 @@
                                     { key => "DVD", value => 1 },
                                     { key => "ISO_MAXSIZE", value => 4700372992 },
                                     { key => "NOIMAGES", value => 1 },
+                                    { key => "SCC_REGISTER", value => "never" },
                                   ],
                       version  => "*",
                     },

--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -94,7 +94,7 @@ sub run {
 
     # license+lang +product (on sle15)
     # On sle 15 license is on different screen, here select the product
-    if (sle_version_at_least('15') && check_var('DISTRI', 'sle')) {
+    if (is_sle('15+') && check_var('DISTRI', 'sle')) {
         # On s390x there will be only one product which means there is no product selection
         # In upgrade mode, there is no product list shown in welcome screen
         unless (check_var('ARCH', 's390x') || get_var('UPGRADE')) {


### PR DESCRIPTION
[WIP] trial to test a sles12sp3 iso in openqa openSUSE distro

This "sles12sp3_trial" branch as a correq branch for needles in https://github.com/michelmno/os-autoinst-needles-opensuse/commit/bba73f7d1921236b0fb2378af5d4d51546da8e0c

In prereq to the commits listed later, I made following manual changes in openQA host.
(I do not have a clean solution to replace this dirty change)
```
===
[root@abanc:/var/lib/openqa/share/tests]
$ln -s opensuse sle
$ls -ltr
lrwxrwxrwx  1 root      root    8 Jul 13 15:41 sle -> opensuse
drwxr-xr-x 10 root      root 4.0K Jul 16 18:15 opensuse
===
[root@abanc:/var/lib/openqa/share/tests/sle/products/sle]
$ln -s ../opensuse/needles needles
$ls -ltr
-rwxr-xr-x 1 root root 15K Sep  1  2017 templates
-rw-r--r-- 1 root root 39K Jun 25 12:36 main.pm
lrwxrwxrwx 1 root root  19 Jul 13 15:52 needles -> ../opensuse/needles
===
```
I do not use the sle/templates but the opensuse/templates

I verified a sles12sp3 ppc64le install with install_gnome test.
